### PR TITLE
Cast void data pointer to const char * to fix gcc

### DIFF
--- a/src/modules/hellotimer.c
+++ b/src/modules/hellotimer.c
@@ -40,7 +40,7 @@
 /* Timer callback. */
 void timerHandler(RedisModuleCtx *ctx, void *data) {
     REDISMODULE_NOT_USED(ctx);
-    printf("Fired %s!\n", data);
+    printf("Fired %s!\n", (const char *) data);
     RedisModule_Free(data);
 }
 


### PR DESCRIPTION
This was causing some compiler errors under GCC, since `void*` and `const char*` are not guaranteed to be the same size on certain platforms.