### PR TITLE
Dockerfile: add missing libcurl4-openssl-dev dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:18.04
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -qqy \
-        build-essential nasm autotools-dev autoconf libjemalloc-dev tcl tcl-dev uuid-dev \
+        build-essential nasm autotools-dev autoconf libcurl4-openssl-dev libjemalloc-dev tcl tcl-dev uuid-dev \
     && apt-get clean
 
 CMD make


### PR DESCRIPTION
Adds a missing libcurl4-openssl-dev to the dockerfile.