### PR TITLE
Fix keydb-cli crashing on read-only filesystem

### DIFF
--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -6594,6 +6594,8 @@ static char *fetchMOTDFromCache()
 static void setMOTDCache(const char *sz)
 {
     FILE *pf = fopen(szMotdCachePath(), "wb");
+    if (pf == NULL)
+        return;
     size_t celem = fwrite(sz, strlen(sz), 1, pf);
     (void)celem;    // best effort
     fclose(pf);


### PR DESCRIPTION
The `keydb-cli` tool segfaults if it is not able to store the MOTD cache file as can be the case in certain container environments.

Run below commands to reproduce the crash (prior to applying this patch):

```shell
rm -f ~/.keydb-cli-motd
touch ~/.keydb-cli-motd
chmod a= ~/.keydb-cli-motd
keydb-cli
```
