### PR TITLE
Clang requires libatomic to be linked via LDFLAGS

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -70,6 +70,7 @@ endif
 
 ifeq ($(COMPILER_NAME),clang)
 	CXXFLAGS+= -stdlib=libc++ 
+	LDFLAGS+= -latomic
 endif
 
 # To get ARM stack traces if Redis crashes we need a special C flag.


### PR DESCRIPTION
Clang requires the libatomic to be linked via LDFLAGS or else the linker
will fail to recognise __atomic macros.

An error as a result of not passing -latomic to the linker can be seen
below:

ld.lld: error: undefined symbol: __atomic_fetch_add_2
>>> referenced by sds.c:185
>>>               lto.tmp:(sdsdupshared)
clang-10: error: linker command failed with exit code 1 (use -v to see invocation)
make[1]: *** [Makefile:276: keydb-server] Error 1