### PR TITLE
acl: @replication command group

### DIFF
--- a/keydb.conf
+++ b/keydb.conf
@@ -376,9 +376,9 @@ dir ./
 #
 # However this is not enough if you are using KeyDB ACLs (for Redis version
 # 6 or greater), and the default user is not capable of running the PSYNC
-# command and/or other commands needed for replication. In this case it's
-# better to configure a special user to use with replication, and specify the
-# masteruser configuration as such:
+# command and/or other commands needed for replication (gathered in the
+# @replication group). In this case it's better to configure a special user to
+# use with replication, and specify the masteruser configuration as such:
 #
 # masteruser <username>
 #

--- a/src/acl.cpp
+++ b/src/acl.cpp
@@ -79,6 +79,7 @@ struct ACLCategoryItem {
     {"connection", CMD_CATEGORY_CONNECTION},
     {"transaction", CMD_CATEGORY_TRANSACTION},
     {"scripting", CMD_CATEGORY_SCRIPTING},
+    {"replication", CMD_CATEGORY_REPLICATION},
     {NULL,0} /* Terminator. */
 };
 

--- a/src/help.h
+++ b/src/help.h
@@ -18,7 +18,8 @@ static char *commandGroups[] = {
     "hyperloglog",
     "cluster",
     "geo",
-    "stream"
+    "stream",
+    "replication"
 };
 
 struct commandHelp {

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -180,7 +180,7 @@ volatile unsigned long lru_clock; /* Server global current LRU time. */
  *
  * @keyspace, @read, @write, @set, @sortedset, @list, @hash, @string, @bitmap,
  * @hyperloglog, @stream, @admin, @fast, @slow, @pubsub, @blocking, @dangerous,
- * @connection, @transaction, @scripting, @geo.
+ * @connection, @transaction, @scripting, @geo, @replication.
  *
  * Note that:
  *
@@ -673,7 +673,7 @@ struct redisCommand redisCommandTable[] = {
      * failure detection, and a loading server is considered to be
      * not available. */
     {"ping",pingCommand,-1,
-     "ok-stale fast @connection",
+     "ok-stale fast @connection @replication",
      0,NULL,0,0,0,0,0,0},
 
     {"echo",echoCommand,2,
@@ -717,15 +717,15 @@ struct redisCommand redisCommandTable[] = {
      0,NULL,0,0,0,0,0,0},
 
     {"sync",syncCommand,1,
-     "admin no-script",
+     "admin no-script @replication",
      0,NULL,0,0,0,0,0,0},
 
     {"psync",syncCommand,3,
-     "admin no-script",
+     "admin no-script @replication",
      0,NULL,0,0,0,0,0,0},
 
     {"replconf",replconfCommand,-1,
-     "admin no-script ok-loading ok-stale",
+     "admin no-script ok-loading ok-stale @replication",
      0,NULL,0,0,0,0,0,0},
 
     {"flushdb",flushdbCommand,-1,

--- a/src/server.h
+++ b/src/server.h
@@ -372,7 +372,8 @@ public:
 #define CMD_CATEGORY_CONNECTION (1ULL<<36)
 #define CMD_CATEGORY_TRANSACTION (1ULL<<37)
 #define CMD_CATEGORY_SCRIPTING (1ULL<<38)
-#define CMD_SKIP_PROPOGATE (1ULL<<39)  /* "noprop" flag */
+#define CMD_CATEGORY_REPLICATION (1ULL<<39)
+#define CMD_SKIP_PROPOGATE (1ULL<<40)  /* "noprop" flag */
 
 /* AOF states */
 #define AOF_OFF 0             /* AOF is off */

--- a/utils/generate-command-help.rb
+++ b/utils/generate-command-help.rb
@@ -15,7 +15,8 @@ GROUPS = [
   "hyperloglog",
   "cluster",
   "geo",
-  "stream"
+  "stream",
+  "replication"
 ].freeze
 
 GROUPS_BY_NAME = Hash[*


### PR DESCRIPTION
Currently the documentation says:
```
# […]
# However this is not enough if you are using KeyDB ACLs (for Redis version
# 6 or greater), and the default user is not capable of running the PSYNC
# command and/or other commands needed for replication. In this case it's
# better to configure a special user to use with replication, and specify the
# masteruser configuration as such:
#
# masteruser <username>
```

Well, great but what are the "other commands needed for replication" ?

I dug a bit and found that needed commands are:

* psync
* ping
* replconf

So I propose to create a group called @replication (or whatever) which would contain all the "needed commands for replication".

I also included the old command "sync" but I don't know if really necessary.

# notes

I am not a keydb developer and build this list from what I understood of the code.
I may be wrong.

I also post this PR on the redis repo: https://github.com/antirez/redis/pull/7180