### PR TITLE
Optimize rdbEncodeInteger using bit operations

### DIFF
--- a/src/rdb.cpp
+++ b/src/rdb.cpp
@@ -239,25 +239,38 @@ uint64_t rdbLoadLen(rio *rdb, int *isencoded) {
  * representation is stored in the buffer pointer to by "enc" and the string
  * length is returned. Otherwise 0 is returned. */
 int rdbEncodeInteger(long long value, unsigned char *enc) {
-    if (value >= -(1<<7) && value <= (1<<7)-1) {
+    struct SignExtendBits{        
+        long long bits8:  8;        
+        long long bits16: 16;
+        long long bits32: 32;
+    } v;
+    
+    v.bits8 = value;
+    if (v.bits8 == value) {
         enc[0] = (RDB_ENCVAL<<6)|RDB_ENC_INT8;
-        enc[1] = value&0xFF;
+        enc[1] = v.bits8;
         return 2;
-    } else if (value >= -(1<<15) && value <= (1<<15)-1) {
+    }
+
+    v.bits16 = value;
+    if (v.bits16 == value) {
         enc[0] = (RDB_ENCVAL<<6)|RDB_ENC_INT16;
         enc[1] = value&0xFF;
         enc[2] = (value>>8)&0xFF;
         return 3;
-    } else if (value >= -((long long)1<<31) && value <= ((long long)1<<31)-1) {
+    }
+
+    v.bits32 = value;
+    if (v.bits32 == value) {
         enc[0] = (RDB_ENCVAL<<6)|RDB_ENC_INT32;
         enc[1] = value&0xFF;
         enc[2] = (value>>8)&0xFF;
         enc[3] = (value>>16)&0xFF;
         enc[4] = (value>>24)&0xFF;
         return 5;
-    } else {
-        return 0;
     }
+
+    return 0;    
 }
 
 /* Loads an integer-encoded object with the specified encoding type "enctype".


### PR DESCRIPTION
use sign extension mov instructions into 8/16/32 bits int registers to check if value fits
into 8/16/32 bit width. 


```
// return number of bytes needed to encode (1,2,4 or 0 if above)
int canEncodeInBytes(long long value){ 
    struct SignExtendBits{
        long long bits8: 8; 
        long long bits16: 16;
        long long bits32: 32;|
    } v;           
    v.bits8 = value;
    if ( v.bits8 == value ) return 1; 
    v.bits16 = value; 
    if ( v.bits16 == value ) return 2; 
    v.bits32 = value; 
    if ( v.bits32 == value ) return 4; 
    return 0; 
} 
```

Compiles to compact code even with -O1 :
```
function(long long):                           # @function(long long)
        movsx   rcx, dil
        mov     eax, 1
        cmp     rcx, rdi
        je      .LBB8_3
        movsx   rcx, di
        mov     eax, 2
        cmp     rcx, rdi
        je      .LBB8_3
        movsxd  rcx, edi
        xor     eax, eax
        cmp     rcx, rdi
        sete    al
        shl     eax, 2
.LBB8_3:
        ret
```