### PR TITLE
 Fix to support FreeBSD pthread_getthreadid_np call

### DIFF
--- a/src/fastlock.cpp
+++ b/src/fastlock.cpp
@@ -35,7 +35,11 @@
 #include <sched.h>
 #include <atomic>
 #include <assert.h>
+#ifdef __FreeBSD__
+#include <pthread_np.h>
+#else
 #include <pthread.h>
+#endif
 #include <limits.h>
 #include <map>
 #ifdef __linux__
@@ -167,7 +171,12 @@ extern "C" pid_t gettid()
 #else
 	if (pidCache == -1) {
 		uint64_t tidT;
+#ifdef __FreeBSD__
+// Check https://github.com/ClickHouse/ClickHouse/commit/8d51824ddcb604b6f179a0216f0d32ba5612bd2e
+                tidT = pthread_getthreadid_np();
+#else
 		pthread_threadid_np(nullptr, &tidT);
+#endif
 		serverAssert(tidT < UINT_MAX);
 		pidCache = (int)tidT;
 	}


### PR DESCRIPTION
I was able to build KeyDB on FreeBSD 11.2 with this fix. FreeBSD has support for uuid, but has different func names, so I decided to install Linux uuid lib with `pkg install e2fsprogs-libuuid`. After that you can build with 

```
gmake CXXFLAGS=-I/usr/local/include LDFLAGS='-luuid -L/usr/local/lib -L/usr/local/lib/gcc7'
```
I believe it is clang compiler, but you need to link with `/usr/local/lib/gcc7/libatomic.a` anyway as it is forced in Makefile.

All tests are fine, except one. I guess it is just unstable branch.

```
*** [err]: replica buffer don't induce eviction in tests/integration/replication.tcl
Expected [::redis::redisHandle58 dbsize] == 100 (context: type eval line 64 cmd {assert {[$master dbsize] == 100}} proc ::test)
```

Run `pkg install retcl-0.3.2` to install tcl