### PR TITLE
Removed dead code from a macro in zmalloc.cpp

### DIFF
--- a/src/zmalloc.cpp
+++ b/src/zmalloc.cpp
@@ -83,17 +83,8 @@ static_assert((PREFIX_SIZE % 16) == 0, "Our prefix must be modulo 16-bytes or ou
 #define realloc(ptr,size,type) realloc(ptr,size)
 #endif
 
-#define update_zmalloc_stat_alloc(__n) do { \
-    size_t _n = (__n); \
-    if (_n&(sizeof(long)-1)) _n += sizeof(long)-(_n&(sizeof(long)-1)); \
-    atomicIncr(used_memory,__n); \
-} while(0)
-
-#define update_zmalloc_stat_free(__n) do { \
-    size_t _n = (__n); \
-    if (_n&(sizeof(long)-1)) _n += sizeof(long)-(_n&(sizeof(long)-1)); \
-    atomicDecr(used_memory,__n); \
-} while(0)
+#define update_zmalloc_stat_alloc(__n) atomicIncr(used_memory,(__n))
+#define update_zmalloc_stat_free(__n) atomicDecr(used_memory,(__n))
 
 static size_t used_memory = 0;
 pthread_mutex_t used_memory_mutex = PTHREAD_MUTEX_INITIALIZER;


### PR DESCRIPTION
I think the compiler would have removed this no-op anyways but it
definitely wasted me some 30 minutes on this :(

I was hoping I could remove the branch through some bit-hacking but
apparently its dead code :). Oh well, its 30 minutes of refreshing
bit hacking.

1. Is there a progress on this [mimalloc request](https://github.com/JohnSully/KeyDB/issues/179) in the works?

2. What do you think of using `std::atomic<std::size_t>` to replace the "variable + mutex" pattern?

Signed-off-by: Hanif Bin Ariffin <hanif.ariffin.4326@gmail.com>