### PR TITLE
Fixed a macro in rax_malloc.h to correctly (?) pass the argument.

### DIFF
--- a/src/rax_malloc.h
+++ b/src/rax_malloc.h
@@ -40,5 +40,5 @@
 #include "zmalloc.h"
 #define rax_malloc(size) zmalloc(size, MALLOC_SHARED)
 #define rax_realloc(ptr, size) zrealloc(ptr, size, MALLOC_SHARED)
-#define rax_free zfree
+#define rax_free(ptr) zfree((ptr))
 #endif


### PR DESCRIPTION
I am not entirely sure if this actually worked before...wtf?

Found it while I was trying to optimize `raxStack` further using the last pointer in the stack-array to point to the heap allocation one so we don't have to memcpy stuff around.
We are currently performing 2 indirections through `raxStack->stack->` anyways.
Still couldn't flesh out the details of this implementation yet.
I have tried several variations but they all have pretty bad pathological cases.

Edit: If this is too minute of a change I can reuse this to include the optimization later.
