### PR TITLE
Fixed non-empty check in src/Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -47,7 +47,7 @@ endif
 
 USEASM?=true
 
-ifneq ($(SANITIZE),)
+ifneq ($(strip $(SANITIZE)),)
 	CFLAGS+= -fsanitize=$(SANITIZE) -DSANITIZE
 	CXXFLAGS+= -fsanitize=$(SANITIZE) -DSANITIZE
 	LDFLAGS+= -fsanitize=$(SANITIZE)


### PR DESCRIPTION
Per [GNU Make Manual](https://www.gnu.org/software/make/manual/html_node/Conditional-Syntax.html).
To properly check for non-empty variable, one must strip whitespaces.

Signed-off-by: Hanif Bin Ariffin <hanif.ariffin.4326@gmail.com>