### PR TITLE
Make MOTD configurable

### DIFF
--- a/keydb.conf
+++ b/keydb.conf
@@ -282,6 +282,9 @@ databases 16
 # ASCII art logo in startup logs by setting the following option to yes.
 always-show-logo yes
 
+# Retrieving "message of today" using CURL requests.
+enable-motd true
+
 ################################ SNAPSHOTTING  ################################
 #
 # Save the DB on disk:

--- a/keydb.conf
+++ b/keydb.conf
@@ -283,7 +283,7 @@ databases 16
 always-show-logo yes
 
 # Retrieving "message of today" using CURL requests.
-enable-motd true
+enable-motd no
 
 ################################ SNAPSHOTTING  ################################
 #

--- a/keydb.conf
+++ b/keydb.conf
@@ -283,7 +283,7 @@ databases 16
 always-show-logo yes
 
 # Retrieving "message of today" using CURL requests.
-enable-motd no
+#enable-motd yes
 
 ################################ SNAPSHOTTING  ################################
 #

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -2344,7 +2344,7 @@ standardConfig configs[] = {
     createBoolConfig("daemonize", NULL, IMMUTABLE_CONFIG, cserver.daemonize, 0, NULL, NULL),
     createBoolConfig("lua-replicate-commands", NULL, MODIFIABLE_CONFIG, g_pserver->lua_always_replicate_commands, 1, NULL, NULL),
     createBoolConfig("always-show-logo", NULL, IMMUTABLE_CONFIG, g_pserver->always_show_logo, 0, NULL, NULL),
-    createBoolConfig("enable-motd", NULL, IMMUTABLE_CONFIG, g_pserver->enable_motd, 0, NULL, NULL),
+    createBoolConfig("enable-motd", NULL, IMMUTABLE_CONFIG, cserver.enable_motd, 1, NULL, NULL),
     createBoolConfig("protected-mode", NULL, MODIFIABLE_CONFIG, g_pserver->protected_mode, 1, NULL, NULL),
     createBoolConfig("rdbcompression", NULL, MODIFIABLE_CONFIG, g_pserver->rdb_compression, 1, NULL, NULL),
     createBoolConfig("rdb-del-sync-files", NULL, MODIFIABLE_CONFIG, g_pserver->rdb_del_sync_files, 0, NULL, NULL),

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -2344,6 +2344,7 @@ standardConfig configs[] = {
     createBoolConfig("daemonize", NULL, IMMUTABLE_CONFIG, cserver.daemonize, 0, NULL, NULL),
     createBoolConfig("lua-replicate-commands", NULL, MODIFIABLE_CONFIG, g_pserver->lua_always_replicate_commands, 1, NULL, NULL),
     createBoolConfig("always-show-logo", NULL, IMMUTABLE_CONFIG, g_pserver->always_show_logo, 0, NULL, NULL),
+    createBoolConfig("enable-motd", NULL, IMMUTABLE_CONFIG, g_pserver->enable_motd, 0, NULL, NULL),
     createBoolConfig("protected-mode", NULL, MODIFIABLE_CONFIG, g_pserver->protected_mode, 1, NULL, NULL),
     createBoolConfig("rdbcompression", NULL, MODIFIABLE_CONFIG, g_pserver->rdb_compression, 1, NULL, NULL),
     createBoolConfig("rdb-del-sync-files", NULL, MODIFIABLE_CONFIG, g_pserver->rdb_del_sync_files, 0, NULL, NULL),

--- a/src/motd.cpp
+++ b/src/motd.cpp
@@ -128,7 +128,7 @@ extern "C" char *fetchMOTD(int cache, int enable_motd)
 
 #else
 
-extern "C" char *fetchMOTD(int /* cache */, int enable_motd)
+extern "C" char *fetchMOTD(int /* cache */, int /* enable_motd */)
 {
     return NULL;
 }

--- a/src/motd.cpp
+++ b/src/motd.cpp
@@ -71,11 +71,15 @@ static void setMOTDCache(const char *sz)
     fclose(pf);
 }
 
-extern "C" char *fetchMOTD(int cache)
+extern "C" char *fetchMOTD(int cache, int enable_motd)
 {
     sds str;
     CURL *curl;
     CURLcode res;
+    /* Do not try the CURL if the motd is disabled*/
+    if (!enable_motd) {
+        return NULL;
+    }
 
     /* First try and get the string from the cache */
     if (cache) {

--- a/src/motd.cpp
+++ b/src/motd.cpp
@@ -128,7 +128,7 @@ extern "C" char *fetchMOTD(int cache, int enable_motd)
 
 #else
 
-extern "C" char *fetchMOTD(int /* cache */)
+extern "C" char *fetchMOTD(int /* cache */, int enable_motd)
 {
     return NULL;
 }

--- a/src/motd.h
+++ b/src/motd.h
@@ -7,7 +7,7 @@ extern const char *motd_cache_file;
 extern "C" {
 #endif
     
-char *fetchMOTD(int fCache);
+char *fetchMOTD(int fCache, int enable_motd);
 
 #ifdef __cplusplus
 }

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -7113,7 +7113,8 @@ int main(int argc, char **argv) {
     if (argc == 0 && !config.eval) {
         /* Show the message of the day if we are interactive */
         if (config.output == OUTPUT_STANDARD && !config.disable_motd) {
-            char *szMotd = fetchMOTD(1 /* cache */);
+	    /*enable_motd=true will retrieve the message of today using CURL*/
+            char *szMotd = fetchMOTD(1 /* cache */, true);
             if (szMotd != NULL) {
                 printf("Message of the day:\n  %s\n", szMotd);
                 sdsfree(szMotd);

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -7113,8 +7113,8 @@ int main(int argc, char **argv) {
     if (argc == 0 && !config.eval) {
         /* Show the message of the day if we are interactive */
         if (config.output == OUTPUT_STANDARD && !config.disable_motd) {
-	    /*enable_motd=true will retrieve the message of today using CURL*/
-            char *szMotd = fetchMOTD(1 /* cache */, true);
+	    /*enable_motd=1 will retrieve the message of today using CURL*/
+            char *szMotd = fetchMOTD(1 /* cache */, 1);
             if (szMotd != NULL) {
                 printf("Message of the day:\n  %s\n", szMotd);
                 sdsfree(szMotd);

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -7114,7 +7114,7 @@ int main(int argc, char **argv) {
         /* Show the message of the day if we are interactive */
         if (config.output == OUTPUT_STANDARD && !config.disable_motd) {
 	    /*enable_motd=1 will retrieve the message of today using CURL*/
-            char *szMotd = fetchMOTD(1 /* cache */, 1);
+            char *szMotd = fetchMOTD(1 /* cache */, 1 /* enable_motd */);
             if (szMotd != NULL) {
                 printf("Message of the day:\n  %s\n", szMotd);
                 sdsfree(szMotd);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -5130,7 +5130,7 @@ void redisAsciiArt(void) {
             mode, g_pserver->port ? g_pserver->port : g_pserver->tls_port
         );
     } else {
-        sds motd = fetchMOTD(true);
+        sds motd = fetchMOTD(true, g_pserver->enable_motd);
         snprintf(buf,1024*16,ascii_logo,
             KEYDB_REAL_VERSION,
             redisGitSHA1(),

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -5130,7 +5130,7 @@ void redisAsciiArt(void) {
             mode, g_pserver->port ? g_pserver->port : g_pserver->tls_port
         );
     } else {
-        sds motd = fetchMOTD(true, g_pserver->enable_motd);
+        sds motd = fetchMOTD(true, cserver.enable_motd);
         snprintf(buf,1024*16,ascii_logo,
             KEYDB_REAL_VERSION,
             redisGitSHA1(),

--- a/src/server.h
+++ b/src/server.h
@@ -1480,6 +1480,7 @@ struct redisServer {
     int sentinel_mode;          /* True if this instance is a Sentinel. */
     size_t initial_memory_usage; /* Bytes used after initialization. */
     int always_show_logo;       /* Show logo even for non-stdout logging. */
+    int enable_motd;            /* Flag to retrieve the Message of today using CURL request*/
     /* Modules */
     dict *moduleapi;            /* Exported core APIs dictionary for modules. */
     dict *sharedapi;            /* Like moduleapi but containing the APIs that

--- a/src/server.h
+++ b/src/server.h
@@ -1456,6 +1456,7 @@ struct redisServerConst {
     bool fUsePro = false;
     int thread_min_client_threshold = 50;
     int multimaster_no_forward;
+    int enable_motd;            /* Flag to retrieve the Message of today using CURL request*/
 };
 
 struct redisServer {
@@ -1480,7 +1481,6 @@ struct redisServer {
     int sentinel_mode;          /* True if this instance is a Sentinel. */
     size_t initial_memory_usage; /* Bytes used after initialization. */
     int always_show_logo;       /* Show logo even for non-stdout logging. */
-    int enable_motd;            /* Flag to retrieve the Message of today using CURL request*/
     /* Modules */
     dict *moduleapi;            /* Exported core APIs dictionary for modules. */
     dict *sharedapi;            /* Like moduleapi but containing the APIs that

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -67,7 +67,7 @@ start_server {tags {"introspection"}} {
             io-threads-do-reads
             tcp-backlog
             always-show-logo
-	    enable-motd
+            enable-motd
             syslog-enabled
             cluster-enabled
             aclfile

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -67,6 +67,7 @@ start_server {tags {"introspection"}} {
             io-threads-do-reads
             tcp-backlog
             always-show-logo
+	    enable-motd
             syslog-enabled
             cluster-enabled
             aclfile


### PR DESCRIPTION
**Problem:**
"Message of the day" will be retrieved via CURL requests when the keydb-server starts . However, this CURL request will introduce some delays when the internet access is blocked in that environment. delay might vary based on CURL timeout. 

**Solution:**
We can make this "Message of the day" as configurable in keydb.conf. KeyDB-server will not retrieve "Message of the day" when the parameter set to no  ( **"enable-motd no"**)

