### PR TITLE
fix for the server crash when the maxclients increased via config set

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -2273,7 +2273,7 @@ static int updateMaxclients(long long val, long long prev, const char **err) {
             }
             return 0;
         }
-        for (int iel = 0; iel < MAX_EVENT_LOOPS; ++iel)
+        for (int iel = 0; iel < cserver.cthreads; ++iel)
         {
             if ((unsigned int) aeGetSetSize(g_pserver->rgthreadvar[iel].el) <
                 g_pserver->maxclients + CONFIG_FDSET_INCR)


### PR DESCRIPTION
KeyDB server crashed when we increased the maxclients via CONFIG SET command. 

Ways to reproduce this error:

- set the maxclients to 20000 in keydb.conf

- start the keydb-server 

- open the keydb-cli and issue "CONFIG SET maxclients 30000"

keydb-server will crash immediately with core dumb file with below error message:
`AE_ASSERT FAILURE ae.cpp: 392`

This PR will solve this crash issue. 

@JohnSully Please let me know if any changes are required for this PR
