### PR TITLE
Added NULL check to function objFromAllocPtr

### DIFF
--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1528,7 +1528,7 @@ void *allocPtrFromObj(robj_roptr o) {
 }
 
 robj *objFromAllocPtr(void *pv) {
-    if (pv && g_pserver->fActiveReplica) {
+    if (pv != nullptr && g_pserver->fActiveReplica) {
         return reinterpret_cast<robj*>(reinterpret_cast<redisObjectExtended*>(pv)+1);
     } 
     return reinterpret_cast<robj*>(pv);

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1528,7 +1528,7 @@ void *allocPtrFromObj(robj_roptr o) {
 }
 
 robj *objFromAllocPtr(void *pv) {
-    if (g_pserver->fActiveReplica) {
+    if (pv && g_pserver->fActiveReplica) {
         return reinterpret_cast<robj*>(reinterpret_cast<redisObjectExtended*>(pv)+1);
     } 
     return reinterpret_cast<robj*>(pv);


### PR DESCRIPTION
Now NULL input will map to NULL output even if active replica is enabled. This should resolve issues pertaining to active defragmentation while active replica is enabled.