### PR TITLE
fix for the server crash when the maxclients increased via config set

### DIFF
--- a/src/ae.cpp
+++ b/src/ae.cpp
@@ -373,6 +373,11 @@ int aeGetSetSize(aeEventLoop *eventLoop) {
     return eventLoop->setsize;
 }
 
+/* Return the current EventLoop. */
+aeEventLoop *aeGetCurrentEventLoop(){
+    return g_eventLoopThisThread;
+}
+
 /* Tells the next iteration/s of the event processing to set timeout of 0. */
 void aeSetDontWait(aeEventLoop *eventLoop, int noWait) {
     if (noWait)

--- a/src/ae.h
+++ b/src/ae.h
@@ -160,6 +160,7 @@ const char *aeGetApiName(void);
 void aeSetBeforeSleepProc(aeEventLoop *eventLoop, aeBeforeSleepProc *beforesleep, int flags);
 void aeSetAfterSleepProc(aeEventLoop *eventLoop, aeBeforeSleepProc *aftersleep, int flags);
 int aeGetSetSize(aeEventLoop *eventLoop);
+aeEventLoop *aeGetCurrentEventLoop();
 int aeResizeSetSize(aeEventLoop *eventLoop, int setsize);
 void aeSetDontWait(aeEventLoop *eventLoop, int noWait);
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -2273,14 +2273,33 @@ static int updateMaxclients(long long val, long long prev, const char **err) {
             }
             return 0;
         }
+	/* Change the SetSize for the current thread first. 
+	 * If any error, return the error message to the client, otherwise, continue to do the same for other threads */
+        if ((unsigned int) aeGetSetSize(aeGetCurrentEventLoop()) <
+                g_pserver->maxclients + CONFIG_FDSET_INCR)
+        {
+            if (aeResizeSetSize(aeGetCurrentEventLoop(),
+                g_pserver->maxclients + CONFIG_FDSET_INCR) == AE_ERR)
+            {
+                *err = "The event loop API used by Redis is not able to handle the specified number of clients";
+                return 0;
+            }
+	    serverLog(LL_DEBUG,"Successfully changed the setsize for current thread %d", ielFromEventLoop(aeGetCurrentEventLoop()));
+        }
+
         for (int iel = 0; iel < cserver.cthreads; ++iel)
         {
+	    if (g_pserver->rgthreadvar[iel].el == aeGetCurrentEventLoop())
+            {
+                continue;
+            }
+
             if ((unsigned int) aeGetSetSize(g_pserver->rgthreadvar[iel].el) <
                 g_pserver->maxclients + CONFIG_FDSET_INCR)
             {
                 int res = aePostFunction(g_pserver->rgthreadvar[iel].el, [iel] {
                     if (aeResizeSetSize(g_pserver->rgthreadvar[iel].el, g_pserver->maxclients + CONFIG_FDSET_INCR) == AE_ERR) {
-                        serverPanic("Failed to change the setsize for Thread %d", iel);
+                        serverLog(LL_WARNING,"Failed to change the setsize for Thread %d", iel);
                     }
                 });
 
@@ -2290,6 +2309,7 @@ static int updateMaxclients(long long val, long long prev, const char **err) {
                     *err = msg;
                     return 0;
                 }
+		serverLog(LL_DEBUG,"Successfully post the request to change the setsize for thread %d", iel);
             }
         }
     }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -2278,10 +2278,12 @@ static int updateMaxclients(long long val, long long prev, const char **err) {
             if ((unsigned int) aeGetSetSize(g_pserver->rgthreadvar[iel].el) <
                 g_pserver->maxclients + CONFIG_FDSET_INCR)
             {
-                if (aeResizeSetSize(g_pserver->rgthreadvar[iel].el,
-                    g_pserver->maxclients + CONFIG_FDSET_INCR) == AE_ERR)
-                {
-                    *err = "The event loop API used by Redis is not able to handle the specified number of clients";
+		int res = aePostFunction(g_pserver->rgthreadvar[iel].el, [iel] {
+                    aeResizeSetSize(g_pserver->rgthreadvar[iel].el, g_pserver->maxclients + CONFIG_FDSET_INCR);
+                });
+
+                if (res != AE_OK){
+                    *err = "Failed to set the setsize for this thread.";
                     return 0;
                 }
             }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -2273,8 +2273,8 @@ static int updateMaxclients(long long val, long long prev, const char **err) {
             }
             return 0;
         }
-	/* Change the SetSize for the current thread first. 
-	 * If any error, return the error message to the client, otherwise, continue to do the same for other threads */
+        /* Change the SetSize for the current thread first. If any error, return the error message to the client, 
+         * otherwise, continue to do the same for other threads */
         if ((unsigned int) aeGetSetSize(aeGetCurrentEventLoop()) <
                 g_pserver->maxclients + CONFIG_FDSET_INCR)
         {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -2276,7 +2276,7 @@ static int updateMaxclients(long long val, long long prev, const char **err) {
         /* Change the SetSize for the current thread first. If any error, return the error message to the client, 
          * otherwise, continue to do the same for other threads */
         if ((unsigned int) aeGetSetSize(aeGetCurrentEventLoop()) <
-                g_pserver->maxclients + CONFIG_FDSET_INCR)
+            g_pserver->maxclients + CONFIG_FDSET_INCR)
         {
             if (aeResizeSetSize(aeGetCurrentEventLoop(),
                 g_pserver->maxclients + CONFIG_FDSET_INCR) == AE_ERR)
@@ -2284,13 +2284,12 @@ static int updateMaxclients(long long val, long long prev, const char **err) {
                 *err = "The event loop API used by Redis is not able to handle the specified number of clients";
                 return 0;
             }
-	    serverLog(LL_DEBUG,"Successfully changed the setsize for current thread %d", ielFromEventLoop(aeGetCurrentEventLoop()));
+            serverLog(LL_DEBUG,"Successfully changed the setsize for current thread %d", ielFromEventLoop(aeGetCurrentEventLoop()));
         }
 
         for (int iel = 0; iel < cserver.cthreads; ++iel)
         {
-	    if (g_pserver->rgthreadvar[iel].el == aeGetCurrentEventLoop())
-            {
+            if (g_pserver->rgthreadvar[iel].el == aeGetCurrentEventLoop()){
                 continue;
             }
 
@@ -2309,7 +2308,7 @@ static int updateMaxclients(long long val, long long prev, const char **err) {
                     *err = msg;
                     return 0;
                 }
-		serverLog(LL_DEBUG,"Successfully post the request to change the setsize for thread %d", iel);
+                serverLog(LL_DEBUG,"Successfully post the request to change the setsize for thread %d", iel);
             }
         }
     }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -2279,7 +2279,9 @@ static int updateMaxclients(long long val, long long prev, const char **err) {
                 g_pserver->maxclients + CONFIG_FDSET_INCR)
             {
                 int res = aePostFunction(g_pserver->rgthreadvar[iel].el, [iel] {
-                    aeResizeSetSize(g_pserver->rgthreadvar[iel].el, g_pserver->maxclients + CONFIG_FDSET_INCR);
+                    if (aeResizeSetSize(g_pserver->rgthreadvar[iel].el, g_pserver->maxclients + CONFIG_FDSET_INCR) == AE_ERR) {
+                        serverPanic("Failed to change the setsize for Thread %d", iel);
+                    }
                 });
 
                 if (res != AE_OK){

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -2278,12 +2278,14 @@ static int updateMaxclients(long long val, long long prev, const char **err) {
             if ((unsigned int) aeGetSetSize(g_pserver->rgthreadvar[iel].el) <
                 g_pserver->maxclients + CONFIG_FDSET_INCR)
             {
-		int res = aePostFunction(g_pserver->rgthreadvar[iel].el, [iel] {
+                int res = aePostFunction(g_pserver->rgthreadvar[iel].el, [iel] {
                     aeResizeSetSize(g_pserver->rgthreadvar[iel].el, g_pserver->maxclients + CONFIG_FDSET_INCR);
                 });
 
                 if (res != AE_OK){
-                    *err = "Failed to set the setsize for this thread.";
+                    static char msg[128];
+                    sprintf(msg, "Failed to post the request to change setsize for Thread %d", iel);
+                    *err = msg;
                     return 0;
                 }
             }


### PR DESCRIPTION
multi threaded KeyDB server  crashed when we increased the maxclients via CONFIG SET command.

**Ways to reproduce this error:**

set the maxclients to 20000 in keydb.conf

start the keydb-server (server-threads = 4)

open the keydb-cli and issue "CONFIG SET maxclients 30000"

keydb-server will crash immediately with core dumb file with below error message:
AE_ASSERT FAILURE ae.cpp: 392

**Solution**

Use the _aePostFunction_ to correctly post the request to corresponding worker thread.

This PR will solve this crash issue.