### PR TITLE
Configurable option for MOTD

### DIFF
--- a/keydb.conf
+++ b/keydb.conf
@@ -282,6 +282,9 @@ databases 16
 # ASCII art logo in startup logs by setting the following option to yes.
 always-show-logo yes
 
+# Retrieving "message of today" using CURL requests.
+#enable-motd yes
+
 ################################ SNAPSHOTTING  ################################
 #
 # Save the DB on disk:

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -2344,6 +2344,7 @@ standardConfig configs[] = {
     createBoolConfig("daemonize", NULL, IMMUTABLE_CONFIG, cserver.daemonize, 0, NULL, NULL),
     createBoolConfig("lua-replicate-commands", NULL, MODIFIABLE_CONFIG, g_pserver->lua_always_replicate_commands, 1, NULL, NULL),
     createBoolConfig("always-show-logo", NULL, IMMUTABLE_CONFIG, g_pserver->always_show_logo, 0, NULL, NULL),
+    createBoolConfig("enable-motd", NULL, IMMUTABLE_CONFIG, cserver.enable_motd, 1, NULL, NULL),
     createBoolConfig("protected-mode", NULL, MODIFIABLE_CONFIG, g_pserver->protected_mode, 1, NULL, NULL),
     createBoolConfig("rdbcompression", NULL, MODIFIABLE_CONFIG, g_pserver->rdb_compression, 1, NULL, NULL),
     createBoolConfig("rdb-del-sync-files", NULL, MODIFIABLE_CONFIG, g_pserver->rdb_del_sync_files, 0, NULL, NULL),

--- a/src/motd.cpp
+++ b/src/motd.cpp
@@ -71,12 +71,16 @@ static void setMOTDCache(const char *sz)
     fclose(pf);
 }
 
-extern "C" char *fetchMOTD(int cache)
+extern "C" char *fetchMOTD(int cache, int enable_motd)
 {
     sds str;
     CURL *curl;
     CURLcode res;
 
+    /* Do not try the CURL if the motd is disabled*/
+    if (!enable_motd) {
+        return NULL;
+    }
     /* First try and get the string from the cache */
     if (cache) {
         str = fetchMOTDFromCache();
@@ -124,7 +128,7 @@ extern "C" char *fetchMOTD(int cache)
 
 #else
 
-extern "C" char *fetchMOTD(int /* cache */)
+extern "C" char *fetchMOTD(int /* cache */, int /* enable_motd */)
 {
     return NULL;
 }

--- a/src/motd.h
+++ b/src/motd.h
@@ -6,8 +6,7 @@ extern const char *motd_cache_file;
 #ifdef __cplusplus
 extern "C" {
 #endif
-    
-char *fetchMOTD(int fCache);
+char *fetchMOTD(int fCache, int enable_motd);
 
 #ifdef __cplusplus
 }

--- a/src/redis-cli.c
+++ b/src/redis-cli.c
@@ -7113,7 +7113,8 @@ int main(int argc, char **argv) {
     if (argc == 0 && !config.eval) {
         /* Show the message of the day if we are interactive */
         if (config.output == OUTPUT_STANDARD && !config.disable_motd) {
-            char *szMotd = fetchMOTD(1 /* cache */);
+            /*enable_motd=1 will retrieve the message of today using CURL*/
+            char *szMotd = fetchMOTD(1 /* cache */, 1 /* enable_motd */);
             if (szMotd != NULL) {
                 printf("Message of the day:\n  %s\n", szMotd);
                 sdsfree(szMotd);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -5136,7 +5136,7 @@ void redisAsciiArt(void) {
             mode, g_pserver->port ? g_pserver->port : g_pserver->tls_port
         );
     } else {
-        sds motd = fetchMOTD(true);
+        sds motd = fetchMOTD(true, cserver.enable_motd);
         snprintf(buf,1024*16,ascii_logo,
             KEYDB_REAL_VERSION,
             redisGitSHA1(),

--- a/src/server.h
+++ b/src/server.h
@@ -1456,6 +1456,7 @@ struct redisServerConst {
     bool fUsePro = false;
     int thread_min_client_threshold = 50;
     int multimaster_no_forward;
+    int enable_motd;            /* Flag to retrieve the Message of today using CURL request*/
 };
 
 struct redisServer {

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -67,6 +67,7 @@ start_server {tags {"introspection"}} {
             io-threads-do-reads
             tcp-backlog
             always-show-logo
+            enable-motd
             syslog-enabled
             cluster-enabled
             aclfile


### PR DESCRIPTION
**Problem:**
"Message of the day" will be retrieved via CURL requests when the keydb-server starts . However, this CURL request will introduce some delays when the internet access is blocked in that environment. delay might vary based on CURL timeout.

**Solution:**
We can make this "Message of the day" as configurable in keydb.conf. KeyDB-server will not retrieve "Message of the day" when the parameter set to no ( "enable-motd no")