### PR TITLE
Allocate 8MB minimum to stack for new server threads

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -5788,9 +5788,13 @@ int main(int argc, char **argv) {
     setOOMScoreAdj(-1);
     serverAssert(cserver.cthreads > 0 && cserver.cthreads <= MAX_EVENT_LOOPS);
     pthread_t rgthread[MAX_EVENT_LOOPS];
+
+    pthread_attr_t tattr;
+    pthread_attr_init(&tattr);
+    pthread_attr_setstacksize(&tattr, 1 << 23); // 8 MB
     for (int iel = 0; iel < cserver.cthreads; ++iel)
     {
-        pthread_create(rgthread + iel, NULL, workerThreadMain, (void*)((int64_t)iel));
+        pthread_create(rgthread + iel, &tattr, workerThreadMain, (void*)((int64_t)iel));
         if (cserver.fThreadAffinity)
         {
 #ifdef __linux__


### PR DESCRIPTION
New server threads need reasonable memory for LZF compression's hash table. This will allocate 8MB minimum, which is the default on Ubuntu. Fixes #204.