### PR TITLE
Calling initServerThread function cserver.cthreads(server-threads) times

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -5695,7 +5695,7 @@ int main(int argc, char **argv) {
 
     validateConfiguration();
 
-    for (int iel = 0; iel < MAX_EVENT_LOOPS; ++iel)
+    for (int iel = 0; iel < cserver.cthreads; ++iel)
     {
         initServerThread(g_pserver->rgthreadvar+iel, iel == IDX_EVENT_LOOP_MAIN);
     }


### PR DESCRIPTION
**initServerThread** has to be called **cserver.cthreads(server-threads)** times not **MAX_EVENT_LOOPS(constant)** times to avoid unnecessary initialization.