### PR TITLE
Fixed various module related deadlocks

### DIFF
--- a/src/ae.cpp
+++ b/src/ae.cpp
@@ -109,13 +109,6 @@ enum class AE_ASYNC_OP
     CreateFileEvent,
 };
 
-struct aeCommandControl
-{
-    std::condition_variable cv;
-    std::atomic<int> rval;
-    std::mutex mutexcv;
-};
-
 struct aeCommand
 {
     AE_ASYNC_OP op;
@@ -128,7 +121,6 @@ struct aeCommand
         std::function<void()> *pfn;
     };
     void *clientData;
-    aeCommandControl *pctl;
 };
 
 void aeProcessCmd(aeEventLoop *eventLoop, int fd, void *, int )
@@ -149,19 +141,7 @@ void aeProcessCmd(aeEventLoop *eventLoop, int fd, void *, int )
             break;
 
         case AE_ASYNC_OP::CreateFileEvent:
-        {
-            if (cmd.pctl != nullptr)
-            {
-                cmd.pctl->mutexcv.lock();
-                std::atomic_store(&cmd.pctl->rval, aeCreateFileEvent(eventLoop, cmd.fd, cmd.mask, cmd.fproc, cmd.clientData));
-                cmd.pctl->cv.notify_all();
-                cmd.pctl->mutexcv.unlock();
-            }
-            else
-            {
-                aeCreateFileEvent(eventLoop, cmd.fd, cmd.mask, cmd.fproc, cmd.clientData);
-            }
-        }
+            aeCreateFileEvent(eventLoop, cmd.fd, cmd.mask, cmd.fproc, cmd.clientData);
             break;
 
         case AE_ASYNC_OP::PostFunction:
@@ -175,19 +155,11 @@ void aeProcessCmd(aeEventLoop *eventLoop, int fd, void *, int )
 
         case AE_ASYNC_OP::PostCppFunction:
         {
-            if (cmd.pctl != nullptr)
-                cmd.pctl->mutexcv.lock();
-            
             std::unique_lock<decltype(g_lock)> ulock(g_lock, std::defer_lock);
             if (cmd.fLock)
                 ulock.lock();
             (*cmd.pfn)();
-            
-            if (cmd.pctl != nullptr)
-            {
-                cmd.pctl->cv.notify_all();
-                cmd.pctl->mutexcv.unlock();
-            }
+
             delete cmd.pfn;
         }
             break;
@@ -226,7 +198,7 @@ ssize_t safe_write(int fd, const void *pv, size_t cb)
 }
 
 int aeCreateRemoteFileEvent(aeEventLoop *eventLoop, int fd, int mask,
-        aeFileProc *proc, void *clientData, int fSynchronous)
+        aeFileProc *proc, void *clientData)
 {
     if (eventLoop == g_eventLoopThisThread)
         return aeCreateFileEvent(eventLoop, fd, mask, proc, clientData);
@@ -239,13 +211,7 @@ int aeCreateRemoteFileEvent(aeEventLoop *eventLoop, int fd, int mask,
     cmd.mask = mask;
     cmd.fproc = proc;
     cmd.clientData = clientData;
-    cmd.pctl = nullptr;
     cmd.fLock = true;
-    if (fSynchronous)
-    {
-        cmd.pctl = new (MALLOC_LOCAL) aeCommandControl();
-        cmd.pctl->mutexcv.lock();
-    }
 
     auto size = safe_write(eventLoop->fdCmdWrite, &cmd, sizeof(cmd));
     if (size != sizeof(cmd))
@@ -253,16 +219,6 @@ int aeCreateRemoteFileEvent(aeEventLoop *eventLoop, int fd, int mask,
         serverAssert(size == sizeof(cmd) || size <= 0);
         serverAssert(errno == EAGAIN);
         ret = AE_ERR;
-    }
-    
-    if (fSynchronous)
-    {
-        {
-        std::unique_lock<std::mutex> ulock(cmd.pctl->mutexcv, std::adopt_lock);
-        cmd.pctl->cv.wait(ulock);
-        ret = cmd.pctl->rval;
-        }
-        delete cmd.pctl;
     }
 
     return ret;
@@ -297,7 +253,6 @@ int aePostFunction(aeEventLoop *eventLoop, std::function<void()> fn, bool fLock,
     aeCommand cmd = {};
     cmd.op = AE_ASYNC_OP::PostCppFunction;
     cmd.pfn = new (MALLOC_LOCAL) std::function<void()>(fn);
-    cmd.pctl = nullptr;
     cmd.fLock = fLock;
 
     auto size = write(eventLoop->fdCmdWrite, &cmd, sizeof(cmd));

--- a/src/ae.h
+++ b/src/ae.h
@@ -135,7 +135,7 @@ aeEventLoop *aeCreateEventLoop(int setsize);
 int aePostFunction(aeEventLoop *eventLoop, aePostFunctionProc *proc, void *arg);
 #ifdef __cplusplus
 }   // EXTERN C
-int aePostFunction(aeEventLoop *eventLoop, std::function<void()> fn, bool fSynchronous = false, bool fLock = true, bool fForceQueue = false);
+int aePostFunction(aeEventLoop *eventLoop, std::function<void()> fn, bool fLock = true, bool fForceQueue = false);
 extern "C" {
 #endif
 void aeDeleteEventLoop(aeEventLoop *eventLoop);

--- a/src/ae.h
+++ b/src/ae.h
@@ -144,7 +144,7 @@ int aeCreateFileEvent(aeEventLoop *eventLoop, int fd, int mask,
         aeFileProc *proc, void *clientData);
 
 int aeCreateRemoteFileEvent(aeEventLoop *eventLoop, int fd, int mask,
-        aeFileProc *proc, void *clientData, int fSynchronous);
+        aeFileProc *proc, void *clientData);
 
 void aeDeleteFileEvent(aeEventLoop *eventLoop, int fd, int mask);
 void aeDeleteFileEventAsync(aeEventLoop *eventLoop, int fd, int mask);

--- a/src/expire.cpp
+++ b/src/expire.cpp
@@ -136,7 +136,7 @@ void activeExpireCycleExpire(redisDb *db, expireEntry &e, long long now) {
                 executeCronJobExpireHook(keyCopy, val);
                 sdsfree(keyCopy);
                 decrRefCount(val);
-            }, false, true /*fLock*/, true /*fForceQueue*/);
+            }, true /*fLock*/, true /*fForceQueue*/);
         }
             return;
 

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -4997,7 +4997,7 @@ void RM_FreeThreadSafeContext(RedisModuleCtx *ctx) {
     zfree(ctx);
 }
 
-__thread bool g_fModuleThread = false;
+thread_local bool g_fModuleThread = false;
 /* Acquire the server lock before executing a thread safe API call.
  * This is not needed for `RedisModule_Reply*` calls when there is
  * a blocked client connected to the thread safe context. */

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -5531,8 +5531,10 @@ void RM_SetClusterFlags(RedisModuleCtx *ctx, uint64_t flags) {
 
 static rax *Timers;     /* The radix tree of all the timers sorted by expire. */
 long long aeTimer = -1; /* Main event loop (ae.c) timer identifier. */
-bool aeTimerSet = false;/* Checks whether the main event loop timer is set
-                           or if an aePostFunction is queued up that will set it */
+static bool aeTimerSet = false;     /* Checks whether the main event loop timer is set */
+static mstime_t aeTimerPeriod;      /* The period of the aeTimer */
+static bool aeTimerPending = false; /* Keeps track of if there is a aePostFunction in flight 
+                                     * that would modify the current main event loop timer */
 
 typedef void (*RedisModuleTimerProc)(RedisModuleCtx *ctx, void *data);
 
@@ -5606,14 +5608,13 @@ RedisModuleTimerID RM_CreateTimer(RedisModuleCtx *ctx, mstime_t period, RedisMod
             expiretime++;
         }
     }
-
     /* We need to install the main event loop timer if it's not already
      * installed, or we may need to refresh its period if we just installed
      * a timer that will expire sooner than any other else. We check here
      * to see if we installed the soonest expiring timer before posting a 
      * function to update it */
     bool isFirstExpiry = false;
-    if (raxSize(Timers) > 0){
+    if (aeTimerSet){
         raxIterator ri;
         raxStart(&ri, Timers);
         raxSeek(&ri,"^",NULL,0);
@@ -5626,20 +5627,31 @@ RedisModuleTimerID RM_CreateTimer(RedisModuleCtx *ctx, mstime_t period, RedisMod
     }
 
     /* Now that either we know that we either need to refresh the period of the
-    *  recently installed timer, or that there is no timer to begin with, we must post
-    *  a function call to install the main event timer */
+     * recently installed timer, or that there is no timer to begin with, we must post
+     * a function call to install the main event timer. */
     if (isFirstExpiry || !aeTimerSet){
+        /* We set the period for the posted function in a global variable
+         * That is so if a function has been posted but not executed, and another
+         * function with a different period were to be posted, we can just update
+         * the period instead of posting a new function. */
+        aeTimerPeriod = period;
         aeTimerSet = true;
-        aePostFunction(g_pserver->rgthreadvar[IDX_EVENT_LOOP_MAIN].el, [period, isFirstExpiry]{
-            /* If we deemed that this timer required a reinstall, delete it before proceeding
-             * to the install */
-            if (isFirstExpiry)
-                aeDeleteTimeEvent(g_pserver->rgthreadvar[IDX_EVENT_LOOP_MAIN].el,aeTimer);
-            /* If we have no main timer (the old one was invalidated, or this is the
-             * first module timer we have), install one. */
-            aeTimer = aeCreateTimeEvent(g_pserver->rgthreadvar[IDX_EVENT_LOOP_MAIN].el,period,moduleTimerHandler,NULL,NULL);
-        });
-    }
+        if (!aeTimerPending) {
+            /* We should only have one aePostFunction in flight at a time, aeTimerPending 
+             * keeps track of that. */
+            aeTimerPending = true;
+            aePostFunction(g_pserver->rgthreadvar[IDX_EVENT_LOOP_MAIN].el, [isFirstExpiry]{
+                /* If we deemed that this timer required a reinstall, delete it before proceeding
+                 * to the install */
+                if (isFirstExpiry)
+                    aeDeleteTimeEvent(g_pserver->rgthreadvar[IDX_EVENT_LOOP_MAIN].el,aeTimer);
+                /* If we have no main timer (the old one was invalidated, or this is the
+                 * first module timer we have), install one. */
+                aeTimer = aeCreateTimeEvent(g_pserver->rgthreadvar[IDX_EVENT_LOOP_MAIN].el,aeTimerPeriod,moduleTimerHandler,NULL,NULL);
+                aeTimerPending = false;
+            });
+        }
+    }   
 
     return key;
 }

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -5531,6 +5531,8 @@ void RM_SetClusterFlags(RedisModuleCtx *ctx, uint64_t flags) {
 
 static rax *Timers;     /* The radix tree of all the timers sorted by expire. */
 long long aeTimer = -1; /* Main event loop (ae.c) timer identifier. */
+bool aeTimerSet = false;/* Checks whether the main event loop timer is set
+                           or if an aePostFunction is queued up that will set it */
 
 typedef void (*RedisModuleTimerProc)(RedisModuleCtx *ctx, void *data);
 
@@ -5605,31 +5607,39 @@ RedisModuleTimerID RM_CreateTimer(RedisModuleCtx *ctx, mstime_t period, RedisMod
         }
     }
 
-    aePostFunction(g_pserver->rgthreadvar[IDX_EVENT_LOOP_MAIN].el, [period, key]{
-        /* We need to install the main event loop timer if it's not already
-        * installed, or we may need to refresh its period if we just installed
-        * a timer that will expire sooner than any other else. */
-        if (aeTimer != -1) {
-            raxIterator ri;
-            raxStart(&ri,Timers);
-            raxSeek(&ri,"^",NULL,0);
-            raxNext(&ri);
-            if (memcmp(ri.key,&key,sizeof(key)) == 0) {
-                /* This is the first key, we need to re-install the timer according
-                * to the just added event. */
+    /* We need to install the main event loop timer if it's not already
+     * installed, or we may need to refresh its period if we just installed
+     * a timer that will expire sooner than any other else. We check here
+     * to see if we installed the soonest expiring timer before posting a 
+     * function to update it */
+    bool isFirstExpiry = false;
+    if (raxSize(Timers) > 0){
+        raxIterator ri;
+        raxStart(&ri, Timers);
+        raxSeek(&ri,"^",NULL,0);
+        raxNext(&ri);    
+        if (memcmp(ri.key,&key,sizeof(key)) == 0)
+            /* This is the first key, we need to re-install the timer according
+             * to the just added event. */
+            isFirstExpiry = true;
+        raxStop(&ri);
+    }
+
+    /* Now that either we know that we either need to refresh the period of the
+    *  recently installed timer, or that there is no timer to begin with, we must post
+    *  a function call to install the main event timer */
+    if (isFirstExpiry || !aeTimerSet){
+        aeTimerSet = true;
+        aePostFunction(g_pserver->rgthreadvar[IDX_EVENT_LOOP_MAIN].el, [period, isFirstExpiry]{
+            /* If we deemed that this timer required a reinstall, delete it before proceeding
+             * to the install */
+            if (isFirstExpiry)
                 aeDeleteTimeEvent(g_pserver->rgthreadvar[IDX_EVENT_LOOP_MAIN].el,aeTimer);
-                aeTimer = -1;
-            }
-            raxStop(&ri);
-        }
-
-        /* If we have no main timer (the old one was invalidated, or this is the
-        * first module timer we have), install one. */
-        if (aeTimer == -1) {
+            /* If we have no main timer (the old one was invalidated, or this is the
+             * first module timer we have), install one. */
             aeTimer = aeCreateTimeEvent(g_pserver->rgthreadvar[IDX_EVENT_LOOP_MAIN].el,period,moduleTimerHandler,NULL,NULL);
-        }
-    });
-
+        });
+    }
 
     return key;
 }

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -5056,7 +5056,14 @@ void moduleAcquireGIL(int fServerThread) {
     }
     else
     {
-        s_mutexModule.lock();
+        // It is possible that another module thread holds the GIL (and s_mutexModule as a result). 
+        // When said thread goes to release the GIL, it will wait for s_mutex, which this thread owns. 
+        // This thread is however waiting for the GIL (and s_mutexModule) that the other thread owns.
+        // As a result, a deadlock has occured. 
+        // We release the lock on s_mutex and wait until we are able to safely acquire the GIL 
+        // in order to prevent this deadlock from occuring. 
+        while (!s_mutexModule.try_lock())
+            s_cv.wait(lock);         
         ++s_cAcquisitionsModule;
         fModuleGILWlocked++;
     }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -4040,7 +4040,7 @@ bool client::postFunction(std::function<void(client *)> fn, bool fLock) {
         std::lock_guard<decltype(this->lock)> lock(this->lock);
         fn(this);
         --casyncOpsPending;
-    }, false, fLock) == AE_OK;
+    }, fLock) == AE_OK;
 }
 
 /*================================== Shutdown =============================== */


### PR DESCRIPTION
Fixed various module related deadlocks through the following:
- Removed synchronous calls to aePostFunction as they were causing issues with the GIL and deadlocking. 
- Changed the scope of g_fModuleThread from static to thread local in order to properly determine whether a thread was spawned by a module or not. 
- Fixed scenario where module thread waiting for s_mutexModule in moduleAcquireGIL can deadlock with module thread waiting for s_mutex in moduleReleaseGIL by allowing s_mutex to be released while waiting for s_mutexModule.