### PR TITLE
Added replica pinging during key load callback + relevant configs

### DIFF
--- a/keydb.conf
+++ b/keydb.conf
@@ -1885,8 +1885,9 @@ jemalloc-bg-thread yes
 # The callback runs during key load to ping other servers and prevent timeouts.
 # It also updates load time estimates.
 # Change these values to run it more or less often. It will run when either condition is true.
-# loading-process-events-interval-bytes 2097152 # Run when x bytes have been processed
-# loading-process-events-interval-keys 8192     # Run when x keys have been loaded
+# Either when x bytes have been processed, or when x keys have been loaded.
+# loading-process-events-interval-bytes 2097152
+# loading-process-events-interval-keys 8192
 
 # Avoid forwarding RREPLAY messages to other masters?
 #   WARNING: This setting is dangerous! You must be certain all masters are connected to each

--- a/keydb.conf
+++ b/keydb.conf
@@ -1881,6 +1881,13 @@ jemalloc-bg-thread yes
 #  Tuning this parameter is a tradeoff between locking overhead and distributing the workload over multiple cores
 # min-clients-per-thread 50
 
+# How often to run RDB load progress callback?
+# The callback runs during key load to ping other servers and prevent timeouts.
+# It also updates load time estimates.
+# Change these values to run it more or less often. It will run when either condition is true.
+# loading-process-events-interval-bytes 2097152 # Run when x bytes have been processed
+# loading-process-events-interval-keys 8192     # Run when x keys have been loaded
+
 # Avoid forwarding RREPLAY messages to other masters?
 #   WARNING: This setting is dangerous! You must be certain all masters are connected to each
 #   other in a true mesh topology or data loss will occur!

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -2467,7 +2467,7 @@ standardConfig configs[] = {
 
     /* Long configs */
     createLongConfig("loading-process-events-interval-bytes", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, g_pserver->loading_process_events_interval_bytes, 2*1024*1024, MEMORY_CONFIG, NULL, NULL),
-    createLongConfig("loading-process-events-interval-keys", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, g_pserver->loading_process_events_interval_keys, 10000, MEMORY_CONFIG, NULL, NULL),
+    createLongConfig("loading-process-events-interval-keys", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, g_pserver->loading_process_events_interval_keys, 8192, MEMORY_CONFIG, NULL, NULL),
     /* Unsigned Long configs */
     createULongConfig("active-defrag-max-scan-fields", NULL, MODIFIABLE_CONFIG, 1, LONG_MAX, cserver.active_defrag_max_scan_fields, 1000, INTEGER_CONFIG, NULL, NULL), /* Default: keys with more than 1000 fields will be processed separately */
     createULongConfig("slowlog-max-len", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, g_pserver->slowlog_max_len, 128, INTEGER_CONFIG, NULL, NULL),

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -2467,6 +2467,7 @@ standardConfig configs[] = {
 
     /* Long configs */
     createLongConfig("loading-process-events-interval-bytes", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, g_pserver->loading_process_events_interval_bytes, 2*1024*1024, MEMORY_CONFIG, NULL, NULL),
+    createLongConfig("loading-process-events-interval-keys", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, g_pserver->loading_process_events_interval_keys, 10000, MEMORY_CONFIG, NULL, NULL),
     /* Unsigned Long configs */
     createULongConfig("active-defrag-max-scan-fields", NULL, MODIFIABLE_CONFIG, 1, LONG_MAX, cserver.active_defrag_max_scan_fields, 1000, INTEGER_CONFIG, NULL, NULL), /* Default: keys with more than 1000 fields will be processed separately */
     createULongConfig("slowlog-max-len", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, g_pserver->slowlog_max_len, 128, INTEGER_CONFIG, NULL, NULL),

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -2465,6 +2465,8 @@ standardConfig configs[] = {
     /* Unsigned int configs */
     createUIntConfig("maxclients", NULL, MODIFIABLE_CONFIG, 1, UINT_MAX, g_pserver->maxclients, 10000, INTEGER_CONFIG, NULL, updateMaxclients),
 
+    /* Long configs */
+    createLongConfig("loading-process-events-interval-bytes", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, g_pserver->loading_process_events_interval_bytes, 2*1024*1024, MEMORY_CONFIG, NULL, NULL),
     /* Unsigned Long configs */
     createULongConfig("active-defrag-max-scan-fields", NULL, MODIFIABLE_CONFIG, 1, LONG_MAX, cserver.active_defrag_max_scan_fields, 1000, INTEGER_CONFIG, NULL, NULL), /* Default: keys with more than 1000 fields will be processed separately */
     createULongConfig("slowlog-max-len", NULL, MODIFIABLE_CONFIG, 0, LONG_MAX, g_pserver->slowlog_max_len, 128, INTEGER_CONFIG, NULL, NULL),

--- a/src/rdb.cpp
+++ b/src/rdb.cpp
@@ -2188,6 +2188,12 @@ void rdbLoadProgressCallback(rio *r, const void *buf, size_t len) {
         processEventsWhileBlocked(serverTL - g_pserver->rgthreadvar);
         processModuleLoadingProgressEvent(0);
 
+        robj *ping_argv[1];
+
+        ping_argv[0] = createStringObject("PING",4);
+        replicationFeedSlaves(g_pserver->slaves, g_pserver->replicaseldb, ping_argv, 1);
+        decrRefCount(ping_argv[0]);
+
         r->loaded_keys = 0;
     }
 }

--- a/src/rdb.cpp
+++ b/src/rdb.cpp
@@ -2169,7 +2169,7 @@ void rdbLoadProgressCallback(rio *r, const void *buf, size_t len) {
     if ((g_pserver->loading_process_events_interval_bytes &&
         (r->processed_bytes + len)/g_pserver->loading_process_events_interval_bytes > r->processed_bytes/g_pserver->loading_process_events_interval_bytes) ||
         (g_pserver->loading_process_events_interval_keys &&
-        (r->loaded_keys >= g_pserver->loading_process_events_interval_keys)))
+        (r->keys_since_last_callback >= g_pserver->loading_process_events_interval_keys)))
     {
         /* The DB can take some non trivial amount of time to load. Update
          * our cached time since it is used to create and update the last
@@ -2194,7 +2194,7 @@ void rdbLoadProgressCallback(rio *r, const void *buf, size_t len) {
         replicationFeedSlaves(g_pserver->slaves, g_pserver->replicaseldb, ping_argv, 1);
         decrRefCount(ping_argv[0]);
 
-        r->loaded_keys = 0;
+        r->keys_since_last_callback = 0;
     }
 }
 
@@ -2501,7 +2501,7 @@ int rdbLoadRio(rio *rdb, int rdbflags, rdbSaveInfo *rsi) {
         if (g_pserver->key_load_delay)
             usleep(g_pserver->key_load_delay);
 
-        rdb->loaded_keys++;
+        rdb->keys_since_last_callback++;
 
         /* Reset the state that is key-specified and is populated by
          * opcodes before the key, so that we start from scratch again. */

--- a/src/redis-check-rdb.cpp
+++ b/src/redis-check-rdb.cpp
@@ -354,6 +354,7 @@ int redis_check_rdb_main(int argc, const char **argv, FILE *fp) {
     if (shared.integers[0] == NULL)
         createSharedObjects();
     g_pserver->loading_process_events_interval_bytes = 0;
+    g_pserver->loading_process_events_interval_keys = 0;
     rdbCheckMode = 1;
     rdbCheckInfo("Checking RDB file %s", argv[1]);
     rdbCheckSetupSignals();

--- a/src/rio.cpp
+++ b/src/rio.cpp
@@ -94,6 +94,7 @@ static const rio rioBufferIO = {
     0,              /* current checksum */
     0,              /* flags */
     0,              /* bytes read or written */
+    0,              /* keys loaded */
     0,              /* read/write chunk size */
     { { NULL, 0 } } /* union for io-specific vars */
 };
@@ -148,6 +149,7 @@ static const rio rioFileIO = {
     0,              /* current checksum */
     0,              /* flags */
     0,              /* bytes read or written */
+    0,              /* keys loaded */
     0,              /* read/write chunk size */
     { { NULL, 0 } } /* union for io-specific vars */
 };
@@ -243,6 +245,7 @@ static const rio rioConnIO = {
     0,              /* current checksum */
     0,              /* flags */
     0,              /* bytes read or written */
+    0,              /* keys loaded */
     0,              /* read/write chunk size */
     { { NULL, 0 } } /* union for io-specific vars */
 };
@@ -361,6 +364,7 @@ static const rio rioFdIO = {
     0,              /* current checksum */
     0,              /* flags */
     0,              /* bytes read or written */
+    0,              /* keys loaded */
     0,              /* read/write chunk size */
     { { NULL, 0 } } /* union for io-specific vars */
 };

--- a/src/rio.cpp
+++ b/src/rio.cpp
@@ -94,7 +94,7 @@ static const rio rioBufferIO = {
     0,              /* current checksum */
     0,              /* flags */
     0,              /* bytes read or written */
-    0,              /* keys loaded */
+    0,              /* keys since last callback */
     0,              /* read/write chunk size */
     { { NULL, 0 } } /* union for io-specific vars */
 };
@@ -149,7 +149,7 @@ static const rio rioFileIO = {
     0,              /* current checksum */
     0,              /* flags */
     0,              /* bytes read or written */
-    0,              /* keys loaded */
+    0,              /* keys since last callback */
     0,              /* read/write chunk size */
     { { NULL, 0 } } /* union for io-specific vars */
 };
@@ -245,7 +245,7 @@ static const rio rioConnIO = {
     0,              /* current checksum */
     0,              /* flags */
     0,              /* bytes read or written */
-    0,              /* keys loaded */
+    0,              /* keys since last callback */
     0,              /* read/write chunk size */
     { { NULL, 0 } } /* union for io-specific vars */
 };
@@ -364,7 +364,7 @@ static const rio rioFdIO = {
     0,              /* current checksum */
     0,              /* flags */
     0,              /* bytes read or written */
-    0,              /* keys loaded */
+    0,              /* keys since last callback */
     0,              /* read/write chunk size */
     { { NULL, 0 } } /* union for io-specific vars */
 };

--- a/src/rio.h
+++ b/src/rio.h
@@ -62,8 +62,8 @@ struct _rio {
     /* The current checksum and flags (see RIO_FLAG_*) */
     uint64_t cksum, flags;
 
-    /* number of keys loaded in transaction */
-    long int loaded_keys;
+    /* number of keys loaded since last rdbLoadProgressCallback */
+    long int keys_since_last_callback;
 
     /* number of bytes read or written */
     size_t processed_bytes;

--- a/src/rio.h
+++ b/src/rio.h
@@ -63,7 +63,7 @@ struct _rio {
     uint64_t cksum, flags;
 
     /* number of keys loaded in transaction */
-    size_t loaded_keys;
+    long int loaded_keys;
 
     /* number of bytes read or written */
     size_t processed_bytes;

--- a/src/rio.h
+++ b/src/rio.h
@@ -62,6 +62,9 @@ struct _rio {
     /* The current checksum and flags (see RIO_FLAG_*) */
     uint64_t cksum, flags;
 
+    /* number of keys loaded in transaction */
+    size_t loaded_keys;
+
     /* number of bytes read or written */
     size_t processed_bytes;
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2547,7 +2547,6 @@ void initServerConfig(void) {
     g_pserver->cluster_configfile = zstrdup(CONFIG_DEFAULT_CLUSTER_CONFIG_FILE);
     g_pserver->migrate_cached_sockets = dictCreate(&migrateCacheDictType,NULL);
     g_pserver->next_client_id = 1; /* Client IDs, start from 1 .*/
-    g_pserver->loading_process_events_interval_bytes = (1024*1024*2);
 
     g_pserver->lruclock = getLRUClock();
     resetServerSaveParams();

--- a/src/server.h
+++ b/src/server.h
@@ -1515,6 +1515,7 @@ struct redisServer {
     off_t loading_loaded_bytes;
     time_t loading_start_time;
     off_t loading_process_events_interval_bytes;
+    off_t loading_process_events_interval_keys;
 
     int active_expire_enabled;      /* Can be disabled for testing purposes. */
 


### PR DESCRIPTION
Ping replicas during key load to prevent timeouts from the master. Also added 2 new config settings: `loading-process-events-interval-bytes` and `loading-process-events-interval-keys`, which determine how often to run the rdb load callback using bytes processed and keys loaded respectively.